### PR TITLE
fix generated report-text

### DIFF
--- a/huggle/Requests/ReportRequests.vb
+++ b/huggle/Requests/ReportRequests.vb
@@ -316,7 +316,12 @@ Namespace Requests
                 If i < Math.Min(Config.MaxReportLinks - 1, RevertedEdits.Count - 1) Then Links &= ", "
             Next i
 
-            Return Links & "</span>"
+            Select Case Config.Project
+                Case "en.wikipedia" : Links &= "</span>"
+                Case "es.wikipedia", "de.wikipedia" : Links &= ""
+            End Select
+
+            Return Links
         End Function
 
         Protected Overrides Sub Done()

--- a/huggle/Requests/ReportRequests.vb
+++ b/huggle/Requests/ReportRequests.vb
@@ -306,7 +306,6 @@ Namespace Requests
 
             Select Case Config.Project
                 Case "en.wikipedia" : Links = ", including <span class=""plainlinks"">"
-                Case "es.wikipedia", "de.wikipedia" : Links = ""
             End Select
 
             For i As Integer = 0 To Math.Min(Config.MaxReportLinks - 1, RevertedEdits.Count - 1)
@@ -318,7 +317,6 @@ Namespace Requests
 
             Select Case Config.Project
                 Case "en.wikipedia" : Links &= "</span>"
-                Case "es.wikipedia", "de.wikipedia" : Links &= ""
             End Select
 
             Return Links


### PR DESCRIPTION
span-tag will be opened only on enwiki (l. 308), so close it only on enwiki.
