### PR TITLE
HG2: modified RC-RegExp after API-Output changed

### DIFF
--- a/huggle/Processing.vb
+++ b/huggle/Processing.vb
@@ -22,8 +22,8 @@ Imports System.Web.HttpUtility
 Module Processing
 
     Private RcLineRegex As New Regex _
-        ("type=""([^""]*)"" ns=""[^""]*"" title=""([^""]*)"" rcid=""([^""]*)"" pageid=""[^""]*"" " _
-        & "revid=""([^""]*)"" old_revid=""([^""]*)"" user=""([^""]*)""( bot="""")?( anon=" _
+        ("type=""([^""]*)"" ns=""[^""]*"" title=""([^""]*)"" pageid=""[^""]*"" " _
+        & "revid=""([^""]*)"" old_revid=""([^""]*)"" rcid=""([^""]*)"" user=""([^""]*)""( bot="""")?( anon=" _
         & """"")?( new="""")?( minor="""")? oldlen=""([^""]*)"" newlen=""([^""]*)"" times" _
         & "tamp=""([^""]*)""( comment=""([^""]*)"")? />", RegexOptions.Compiled)
 
@@ -1132,9 +1132,9 @@ Module Processing
         Dim Edit As New Edit
 
         Edit.Page = GetPage(HtmlDecode(Match.Groups(2).Value))
-        Edit.Rcid = Match.Groups(3).Value
-        Edit.Id = Match.Groups(4).Value
-        Edit.Oldid = Match.Groups(5).Value
+        Edit.Rcid = Match.Groups(5).Value
+        Edit.Id = Match.Groups(3).Value
+        Edit.Oldid = Match.Groups(4).Value
         Edit.User = GetUser(HtmlDecode(Match.Groups(6).Value))
         Edit.Change = (CInt(Match.Groups(12).Value) - CInt(Match.Groups(11).Value))
         Edit.Size = CInt(Match.Groups(12).Value)
@@ -1154,10 +1154,10 @@ Module Processing
         Edit.NewPage = True
         Edit.Page = GetPage(HtmlDecode(Match.Groups(2).Value))
         Edit.Page.FirstEdit = Edit
-        Edit.Rcid = Match.Groups(3).Value
+        Edit.Rcid = Match.Groups(5).Value
         Edit.Page.Rcid = Edit.Rcid
         Edit.Prev = NullEdit
-        Edit.Id = Match.Groups(4).Value
+        Edit.Id = Match.Groups(3).Value
         Edit.Oldid = "-1"
         Edit.User = GetUser(HtmlDecode(Match.Groups(6).Value))
         Edit.Change = CInt(Match.Groups(12).Value)
@@ -1192,7 +1192,7 @@ Module Processing
                 End If
 
                 NewBlock.Comment = FindString(Summary, "): ")
-                NewBlock.Admin = GetUser(HtmlDecode(Match.Groups(5).Value))
+                NewBlock.Admin = GetUser(HtmlDecode(Match.Groups(6).Value))
                 NewBlock.Time = Date.SpecifyKind(CDate(Match.Groups(12).Value).ToUniversalTime, DateTimeKind.Utc)
 
                 ProcessBlock(NewBlock)
@@ -1203,7 +1203,7 @@ Module Processing
 
                 If Summary.StartsWith("deleted") Then NewDelete.Action = "delete" Else NewDelete.Action = "restore"
                 NewDelete.Page = GetPage(FindString(Summary, "[[", "]]"))
-                NewDelete.Admin = GetUser(HtmlDecode(Match.Groups(5).Value))
+                NewDelete.Admin = GetUser(HtmlDecode(Match.Groups(6).Value))
                 NewDelete.Time = Date.SpecifyKind(CDate(Match.Groups(12).Value).ToUniversalTime, DateTimeKind.Utc)
                 NewDelete.Comment = FindString(Summary, """: ")
 
@@ -1221,7 +1221,7 @@ Module Processing
                     NewProtection.Action = "change"
                 End If
 
-                NewProtection.Admin = GetUser(HtmlDecode(Match.Groups(5).Value))
+                NewProtection.Admin = GetUser(HtmlDecode(Match.Groups(6).Value))
                 NewProtection.Time = Date.SpecifyKind(CDate(Match.Groups(12).Value).ToUniversalTime, DateTimeKind.Utc)
                 NewProtection.Page = GetPage(FindString(Summary, "[[", "]]"))
 

--- a/huggle/User.vb
+++ b/huggle/User.vb
@@ -24,12 +24,15 @@ Class User
     'Represents a user account or anonymous user
 
     'Regex to match IP addresses
-    Private Shared AnonymousRegex As New Regex _
+    Private Shared AnonymousIPv4Regex As New Regex _
         ("((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)", RegexOptions.Compiled)
+    Private Shared AnonymousIPv6Regex As New Regex _
+        ("(?:[A-F0-9]{1,4}:){6}(?:[A-F0-9]{1,4}:[A-F0-9]{1,4}|(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]))", RegexOptions.Compiled)
 
     Private Shared All As New Dictionary(Of String, User)
 
-    Private _Anonymous As Boolean
+    Private _AnonymousIPv4 As Boolean
+    Private _AnonymousIPv6 As Boolean
     Private _EditCount As Integer
     Private _Ignored As Boolean
     Private _Level As UserLevel
@@ -51,7 +54,8 @@ Class User
     Public Sub New(ByVal Name As String)
         _Name = Name
         _EditCount = -1
-        _Anonymous = AnonymousRegex.IsMatch(Name)
+        _AnonymousIPv4 = AnonymousIPv4Regex.IsMatch(Name)
+        _AnonymousIPv6 = AnonymousIPv6Regex.IsMatch(Name)
         _Ignored = Whitelist.Contains(Name)
         If Not All.ContainsKey(Name) Then All.Add(Name, Me)
     End Sub
@@ -64,7 +68,7 @@ Class User
 
     Public ReadOnly Property Anonymous() As Boolean
         Get
-            Return _Anonymous
+            Return _AnonymousIPv4 Or _AnonymousIPv6
         End Get
     End Property
 
@@ -96,6 +100,7 @@ Class User
         Get
             If Not Anonymous Then Return Nothing
 
+            'TODO: currently no range support for IPv6, this will return the full address
             Dim NamePart As String = Name.Substring(0, Name.LastIndexOf("."))
             NamePart = NamePart.Substring(0, NamePart.LastIndexOf("."))
             Return NamePart


### PR DESCRIPTION
The order of the properties in a rc-line of the API-Output changed from ... "rcid", "pageid", "revid", "old_revid" ... to ... "pageid", "revid", "old_revid", "rcid" ... thus failing on the RegExp and the matching groups and consequently displaying any edits in the queues (unless IRC-Feed is used), making huggle useless

This was probably caused by https://gerrit.wikimedia.org/r/107389

So this change modifies the RC-RegExp and the matching group-numbers.

Also I changed NewBlock.Admin, NewDelete.Admin and NewProtection.Admin value from matching group "old_revid" to "user" (if I counted correctly)

Second commit is a nice to have:
detect IPv6 edits as anonymous (but without IP-range support)
