### PR TITLE
Get rid of 'irc.pmtpta.wikimedia.org' reference

### DIFF
--- a/Misc.vb
+++ b/Misc.vb
@@ -197,7 +197,7 @@ Module Misc
         Config.FeedbackLocation = "Project:Huggle"
         Config.IfdLocation = "Wikipedia:IFD"
         Config.IrcChannel = ""
-        Config.IrcServer = "irc.pmtpta.wikimedia.org"
+        Config.IrcServer = "irc.wikimedia.org"
         Config.MfdLocation = "Wikipedia:MFD"
         Config.MonthHeadings = True
         Config.OpenInBrowser = True


### PR DESCRIPTION
It would never have worked, and I wouldn't rely on pmtpa DNS references sitting around for much longer anyway.
